### PR TITLE
Add complete Rego grammar

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -10,6 +10,7 @@ module.exports = grammar({
 
   conflicts: $ => [
     [$.membership],
+    [$.rule_body, $.assignment_operator]
   ],
 
   rules: {
@@ -38,16 +39,16 @@ module.exports = grammar({
     policy: $ => repeat1($.rule),
 
     // rule            = [ "default" ] rule-head { rule-body }
-    rule: $ => prec.left(0, seq(
+    rule: $ => seq(
       optional($.default),
       $.rule_head,
       $.rule_body,
-    )),
+    ),
 
     // rule-head       = var ( rule-head-set | rule-head-obj | rule-head-func | rule-head-comp | "if" )
-    rule_head: $ => prec.left(3, seq(
+    rule_head: $ => prec.right(seq(
       $.var,
-      choice(
+      optional(choice(
         // rule-head-set   = ( "contains" term [ "if" ] ) | ( "[" term "]" )
         seq($.contains, $.term, optional($.if)),
 
@@ -67,7 +68,7 @@ module.exports = grammar({
 
         // if
         $.if,
-    ))),
+      )))),
 
     // rule-head-comp  = ( ":=" | "=" ) term
     rule_head_comp: $ => seq($.assignment_operator, $.term),
@@ -79,7 +80,7 @@ module.exports = grammar({
     ),
 
     // rule-body       = [ "else" [ ( ":=" | "=" ) term ] ] ( "{" query "}" ) | literal
-    rule_body: $ => prec.left(1, seq(
+    rule_body: $ => seq(
       optional(
         seq(
           $.else,
@@ -96,7 +97,7 @@ module.exports = grammar({
         $.literal,
         seq($.assignment, $.term),
       )
-    )),
+    ),
 
     // query           = literal { ( ";" | ( [CR] LF ) ) literal }
     query: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -1,206 +1,398 @@
 module.exports = grammar({
-  name: 'rego',
+  name: "rego",
+
+  extras: $ => [
+    $.comment,
+    /[\s\p{Zs}\uFEFF\u2060\u200B]/,
+  ],
+
+  word: $ => $.keyword,
+
+  conflicts: $ => [
+    [$.membership],
+  ],
 
   rules: {
-    source_file: $ => repeat($._definition),
+    source_file: $ => optional($.module),
 
-    _definition: $ => choice(
-      $.package_definition,
-      $.import_package,
-      $.operator_check,
-      $.comment,
-      $.rego_block,
-      $.builtin_function,
-      $._junk
+    // module          = package { import } policy
+    module: $ => seq(
+      $._package,
+      repeat($._import),
+      optional($.policy),
     ),
 
-    operator: $ => choice(
-      '==',
-      ':=',
-      '=',
-      '!=',
-      '<',
-      '>',
-      '/',
-      '-',
-      '+',
+    // package         = "package" ref
+    _package: $ => seq(
+      $.package,
+      $.ref
     ),
 
-    true: $ => 'true',
-    false: $ => 'false',
-
-    comma: $ => ',',
-
-    comment: $ => /\#.*?\n\r?/,
-
-    function_name: $ => choice(
-      'lower',
-      'is_string',
-      'object.get',
-      'print',
-      'concat',
-      'contains',
-      'time.now_ns',
-      'io.jwt.encode_sign_raw',
-      'io.jwt.encode_sign',
-      'io.jwt.decode',
-      'io.jwt.verify_es256',
-      'strings.replace_n',
-      'http.send',
+    // import          = "import" ref [ "as" var ]
+    _import: $ => seq(
+      $.import, $.ref,
+      optional(seq($.as, $.var))
     ),
 
-    opening_parameter: $ => '(',
+    // policy          = { rule }
+    policy: $ => repeat1($.rule),
 
-    closing_parameter: $ => ')',
+    // rule            = [ "default" ] rule-head { rule-body }
+    rule: $ => prec.right(1, seq(
+      optional($.default),
+      $.rule_head,
+      repeat($.rule_body),
+    )),
 
-    builtin_function: $ => seq(
-      field('function_name',
-        $.function_name
+    // rule-head       = var ( rule-head-set | rule-head-obj | rule-head-func | rule-head-comp | "if" )
+    rule_head: $ => prec.left(2, seq(
+      $.var,
+      choice(
+        // rule-head-set   = ( "contains" term [ "if" ] ) | ( "[" term "]" )
+        choice(
+          seq($.contains, $.term, optional($.if)),
+          seq("[", $.term, "]")
+        ),
+        // rule-head-obj   = "[" term "]" [ rule-head-comp ] [ "if" ]
+        seq(
+          seq("[", $.term, "]"),
+          optional($.rule_head_comp),
+          optional($.if),
+        ),
+
+        // rule-head-func  = "(" rule-args ")" [ rule-head-comp ]
+        seq(
+          seq("(", $.rule_args, ")"),
+          optional($.rule_head_comp),
+          optional($.if),
+        ),
+
+        // if
+        $.if
       ),
-      field('opening_parameter', $.opening_parameter),
-      field('function_body',
-        repeat(
-          choice(
-            $.identifier,
-            $.array_definition,
-            $.true,
-            $.false,
-            $.number,
-            $.object_field,
-            $.string_definition,
-            $.identifier,
-            $.comma,
+    )),
+
+    // rule-head-comp  = ( ":=" | "=" ) term
+    rule_head_comp: $ => seq($.assignment_operator, $.expr),
+
+    // rule-args       = term { "," term }
+    rule_args: $ => seq(
+      $.term,
+      repeat(seq(",", $.term)),
+    ),
+
+    // rule-body       = [ "else" [ ( ":=" | "=" ) term ] ] ( "{" query "}" ) | literal
+    rule_body: $ => seq(
+      optional(
+        seq(
+          $.else,
+          optional(
+            seq(
+              $.assignment_operator,
+              $.term,
+            ),
           ),
         ),
       ),
-      field('closing_parameter', $.closing_parameter),
-    ),
-
-    string_definition: $ => seq(
-      '"',
-      /[a-zA-Z0-9<>@\-._:=\s\/\\]*/,
-      '"',
-    ),
-
-    _array_opening: $ => '[',
-    _array_closing: $ => ']',
-
-    object_field: $ => prec(
-      1,
-      seq(
-        /[a-zA-Z\._]+\[/,
-        choice(
-          $.identifier,
-          $.number,
-          $.object_field,
-          $.string_definition
-        ),
-        $._array_closing,
-      ),
-    ),
-
-    array_definition: $ => seq(
-      $._array_opening,
-      repeat(
-        choice(
-          $.array_definition,
-          $.string_definition,
-          $.identifier,
-          $.identifier,
-          $.number,
-          $.object_field,
-          $.true,
-          $.false,
-          $.comma,
-        ),
-      ),
-      $._array_closing,
-    ),
-
-    operator_check: $ => seq(
       choice(
-        $.identifier,
-        $.builtin_function,
-        $.string_definition,
-        $.object_field,
-        $.array_definition,
-        $.true,
-        $.false,
-      ),
-      $.operator,
-      choice(
-        $.identifier,
-        $.builtin_function,
-        $.string_definition,
-        $.object_field,
-        $.array_definition,
-        $.true,
-        $.false,
-      ),
+        seq("{", $.query, "}"),
+        $.literal
+      )
     ),
 
-    rego_rule: $ => prec(1, choice(
-      $.identifier,
-      $.operator_check,
-      $.array_definition,
-      $.test_case,
-      $.true,
-      $.false,
-    ),),
-
-    test_case: $ => seq(
-      $.identifier,
+    // query           = literal { ( ";" | ( [CR] LF ) ) literal }
+    query: $ => seq(
+      $.literal,
       repeat(
         seq(
-          $.reserved_keywords,
-          $.identifier,
+          choice(";", seq(optional("\r"), "\n")),
+          optional($.literal),
         ),
       ),
     ),
 
-    rego_block: $ => seq(
-      field('rego_rule_name', $.identifier),
+    // literal         = ( some-decl | expr | "not" expr ) { with-modifier }
+    literal: $ => seq(
+      choice($.some_decl, $.expr, seq($.not, $.expr)),
+      repeat($.with_modifier),
+    ),
+
+    // with-modifier   = "with" term "as" term
+    with_modifier: $ => seq($.with, $.term, $.as, $.term),
+
+    // some-decl       = "some" term { "," term } { "in" expr }
+    some_decl: $ => seq(
+      $.some, $.term, repeat(seq(",", $.term)), repeat(seq($.in, $.expr))
+    ),
+
+    // expr            = term | expr-call | expr-infix | expr-every | expr-unary
+    expr: $ => prec.left(1, choice(
+      $.term, $.expr_call, $.expr_infix, $.expr_every, $.expr_parens, $.expr_unary
+    )),
+
+    // expr-parens     = "(" expr ")"
+    expr_parens: $ => prec(-1, seq(
+      "(", $.expr, ")"
+    )),
+
+    // expr-call       = var [ "." var ] "(" [ expr { "," expr } ] ")"
+    expr_call: $ => seq(
+      $.var,
       optional(
-        seq(
-          $.operator,
-          $.identifier,
-        ),
+        seq(".", $.var)
       ),
-      '{',
-      repeat($.rego_rule),
-      '}',
+      "(",
+      optional(
+        seq($.expr, repeat(seq(",", $.expr)))
+      ),
+      ")",
     ),
 
-    _junk: $ => /\n/,
-
-    reserved_keywords: $ => choice(
-      'as',
-      'with',
+    // expr-infix = expr infix-operator expr        
+    expr_infix: $ => prec.left(1,
+      seq($.expr, $.infix_operator, $.expr,),
     ),
 
-    as_keyword: $ => seq(
-      $.reserved_keywords,
-      field('package_alias', $.identifier),
+    // expr-every      = "every" var { "," var } "in" ( term | expr-call | expr-infix ) "{" query "}"
+    expr_every: $ => seq(
+      $.every,
+      $.var,
+      repeat(seq(",", $.var)),
+      $.in,
+      choice($.term, $.expr_call, $.expr_infix),
+      "{", $.query, "}",
     ),
 
-    import_package: $ => seq(
-      'import',
-      field('imported_package_name',
+    // expr-unary      = "-" expr
+    expr_unary: $ => prec.left(-3,
+      seq("-", $.expr)
+    ),
+
+    // term            = ref | var | scalar | array | object | set | array-compr | object-compr | set-compr | membership
+    term: $ => choice(
+      $.ref,
+      $.var,
+      $.scalar,
+      $.array,
+      $.object,
+      $.set,
+      $.array_compr,
+      $.object_compr,
+      $.set_compr,
+      $.membership,
+    ),
+
+    // array-compr     = "[" term "|" rule-body "]"
+    array_compr: $ => seq(
+      "[", $.term, "|", $.query, "]",
+    ),
+
+    // set-compr       = "{" term "|" rule-body "}"
+    set_compr: $ => seq(
+      "{", $.term, "|", $.query, "}",
+    ),
+
+    // object-compr    = "{" object-item "|" rule-body "}"
+    object_compr: $ => seq(
+      "{", $.object_item, "|", $.query, "}",
+    ),
+
+    // infix-operator  = bool-operator | arith-operator | bin-operator
+    infix_operator: $ => choice(
+      prec.left(2, $.assignment_operator), $.bool_operator, $.arith_operator, $.bin_operator
+    ),
+
+    // assignment-operator = ":=" | "="    
+    assignment_operator: $ => choice($.assignment, $.unification),
+
+    // assignment operator
+    assignment: $ => ":=",
+
+    // unification operator
+    unification: $ => "=",
+
+    // bool-operator   = "==" | "!=" | "<" | ">" | ">=" | "<="
+    bool_operator: $ => choice(
+      "==", "!=", "<", ">", ">=", "<="
+    ),
+
+    // arith-operator  = "+" | "-" | "*" | "/"
+    arith_operator: $ => choice(
+      "+", "-", "*", "/"
+    ),
+
+    // bin-operator    = "&" | "|"
+    bin_operator: $ => choice("&", "|"),
+
+    // ref             = ( var | array | object | set | array-compr | object-compr | set-compr | expr-call ) { ref-arg }
+    ref: $ => prec.left(2,
+      seq(
         choice(
-          $.identifier,
+          $.var,
+          $.array,
+          $.object,
+          $.set,
+          $.array_compr,
+          $.object_compr,
+          $.set_compr,
+          $.expr_call,
         ),
+        repeat($.ref_arg),
+      )
+    ),
+
+    // ref-arg         = ref-arg-dot | ref-arg-brack
+    ref_arg: $ => choice(
+      $.ref_arg_dot,
+      $.ref_arg_brack,
+    ),
+
+    // ref-arg-brack   = "[" ( scalar | var | array | object | set | "_" ) "]"
+    ref_arg_brack: $ => seq(
+      "[",
+      choice(
+        $.scalar,
+        $.var,
+        $.array,
+        $.object,
+        $.set,
+        "_",
       ),
-      optional($.as_keyword),
+      "]",
     ),
 
-    package_definition: $ => seq(
-      'package',
-      field('package_name', $.identifier),
+    // ref-arg-dot     = "." var
+    ref_arg_dot: $ => prec.left(2, seq(".", $.var)),
+
+    // var             = ( ALPHA | "_" ) { ALPHA | DIGIT | "_" }
+    var: $ => /[A-Za-z_]+\w*/,
+
+    // scalar          = string | NUMBER | TRUE | FALSE | NULL
+    scalar: $ => choice(
+      $.string,
+      $.number,
+      $.boolean,
+      "null",
     ),
 
-    identifier: $ => /[a-zA-Z\._]+/,
+    // string          = STRING | raw-string
+    string: $ => choice(
+      seq(
+        '"',
+        repeat(
+          token.immediate(/[^\\"\n]+/)
+        ),
+        '"'
+      ),
+      $.raw_string,
+    ),
 
-    number: $ => /\d+/
+    // raw-string      = "`" { CHAR-"`" } "`"
+    raw_string: $ => seq(
+      "`",
+      repeat(
+        token.immediate(/[^`]+/)
+      ),
+      "`",
+    ),
+
+    // array           = "[" term { "," term } "]"
+    array: $ => seq(
+      "[",
+      $.term,
+      repeat(
+        seq(",", $.term)
+      ),
+      "]",
+    ),
+
+    // object          = "{" object-item { "," object-item } "}"
+    object: $ => seq(
+      "{",
+      $.object_item,
+      repeat(
+        seq(",", $.object_item),
+      ),
+      "}",
+    ),
+
+    // object-item     = ( scalar | ref | var ) ":" term
+    object_item: $ => seq(
+      field("key", choice($.scalar, $.ref, $.var)),
+      ":",
+      field("value", $.term),
+    ),
+
+    // set             = empty-set | non-empty-set
+    set: $ => choice($.empty_set, $.non_empty_set),
+
+    // non-empty-set   = "{" term { "," term } "}"
+    non_empty_set: $ => seq(
+      "{",
+      $.term,
+      repeat(
+        seq(",", $.term),
+      ),
+      "}"
+    ),
+
+    // empty-set       = "set(" ")"
+    empty_set: $ => seq("set(", ")"),
+
+    // comment
+    comment: $ => token(seq('#', /.*/)),
+
+    // boolean
+    boolean: $ => choice("true", "false"),
+
+    // membership      = term [ "," term ] "in" term
+    membership: $ => prec.left(-1, seq(
+      $.term,
+      optional(seq(",", $.term)),
+      $.in,
+      $.term,
+    )),
+
+    // number
+    number: $ => /([0-9]*[.])?[0-9]+/,
+
+    // not keyword 
+    not: $ => "not",
+
+    // with keyword
+    with: $ => "with",
+
+    // as keyword
+    as: $ => "as",
+
+    // in keyword
+    in: $ => "in",
+
+    // if keyword
+    if: $ => "if",
+
+    // every keyword        
+    every: $ => "every",
+
+    // else keyword
+    else: $ => "else",
+
+    // package keyword    
+    package: $ => "package",
+
+    // import keyword
+    import: $ => "import",
+
+    // contains keyword
+    contains: $ => "contains",
+
+    // some keyword
+    some: $ => "some",
+
+    // default keyword
+    default: $ => "default",
+
+    // match whole words
+    keyword: $ => /[a-z]+/,
   }
 });
-

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,16 +1,64 @@
 ; highlights.scm
-"import" @include
-"package" @include
+[
+  (import) 
+  (package)
+] @module
 
+[
+  (with)
+  (as)
+  (every)
+  (some)
+  (in)
+  (not)
+  (if)
+  (contains)
+  (else)
+  (default)
+  "null"
+] @keyword
 
-(reserved_keywords) @keyword
+[
+  "true"
+  "false"
+] @boolean
+
+[
+  (assignment_operator)
+  (bool_operator)
+  (arith_operator)
+  (bin_operator)
+] @operator
+
+[
+  (string)
+  (raw_string)
+] @string
+
+(term (ref (var))) @variable
+
 (comment) @comment
-(rego_block rego_rule_name: (identifier) @function)
-(builtin_function function_name: (function_name) @function.builtin)
-(opening_parameter) @punctuation.bracket
-(closing_parameter) @punctuation.bracket
-(string_definition) @string
+
 (number) @number
-(operator) @operator
-(true) @boolean
-(false) @boolean
+
+(expr_call func_name: (fn_name (var) @function .))
+
+(expr_call func_arguments: (fn_args (expr) @variable.parameter))
+
+(rule_args (term) @variable.parameter)
+
+[
+  (open_paren)
+  (close_paren)
+  (open_bracket)
+  (close_bracket)
+  (open_curly)
+  (close_curly)
+] @punctuation.bracket
+
+(rule (rule_head (var) @attribute))
+
+(rule 
+  (rule_head (term (ref (var) @head-var)))
+  (rule_body (query (literal (expr (expr_infix (expr (term (ref (var)) @output-var)))))) (#eq? @output-var @head-var))
+)


### PR DESCRIPTION
Hi @FallenAngel97 I did a clean implementation of the grammar based on https://www.openpolicyagent.org/docs/latest/policy-reference/#grammar and it should be pretty much complete. I still need to add tests and update queries/scms with the new information. However, before I do that I need to talk with OPA/Rego maintainers to verify that some of the changes that I made to the grammar are valid from their point of view (I left my notes in the code), so I'm opening this draft PR first so that I can reference it against the PR that I'm going to open for OPA with the updated grammar..