### PR TITLE
Allow for trailing comma in arrays, objects and sets

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -300,6 +300,7 @@ module.exports = grammar({
       repeat(
         seq(",", $.term)
       ),
+      optional(","),
       $.close_bracket,
     ),
 
@@ -310,6 +311,7 @@ module.exports = grammar({
       repeat(
         seq(",", $.object_item),
       ),
+      optional(","),
       $.close_curly,
     ),
 
@@ -330,6 +332,7 @@ module.exports = grammar({
       repeat(
         seq(",", $.term),
       ),
+      optional(","),
       $.close_curly,
     ),
 


### PR DESCRIPTION
Allow trailing commas on the last item in an array, set or an object
```
array := [
  "a",
  "b",
  "c",
]
```
